### PR TITLE
Fix execution for homebrew pyenv's Python 2 install

### DIFF
--- a/info.plist
+++ b/info.plist
@@ -1205,7 +1205,7 @@
     <key>variables</key>
     <dict>
         <key>PATH</key>
-        <string>/usr/local/bin:/usr/bin:/Library/Frameworks/Python.framework/Versions/2.7/bin</string>
+        <string>/usr/local/bin:/usr/bin:/Library/Frameworks/Python.framework/Versions/2.7/bin:/opt/homebrew/bin</string>
     </dict>
 	<key>webaddress</key>
 	<string>danielecook.com</string>


### PR DESCRIPTION
Follow-up of https://github.com/danielecook/gist-alfred/pull/18
See https://www.alfredapp.com/help/kb/python-2-monterey/

Thanks to @vitorgalvao